### PR TITLE
fix: add jest config in the templates

### DIFF
--- a/src/templates/basic.ts
+++ b/src/templates/basic.ts
@@ -56,6 +56,9 @@ const basicTemplate: Template = {
       singleQuote: true,
       trailingComma: 'es5',
     },
+    jest: {
+      testEnvironment: 'node',
+    },
   },
 };
 

--- a/src/templates/react-with-storybook.ts
+++ b/src/templates/react-with-storybook.ts
@@ -23,6 +23,9 @@ const storybookTemplate: Template = {
       storybook: 'start-storybook -p 6006',
       'build-storybook': 'build-storybook',
     } as PackageJson['scripts'],
+    jest: {
+      testEnvironment: 'jsdom',
+    },
   },
 };
 

--- a/src/templates/react.ts
+++ b/src/templates/react.ts
@@ -22,6 +22,9 @@ const reactTemplate: Template = {
       ...basicTemplate.packageJson.scripts,
       test: 'dts test --passWithNoTests',
     } as PackageJson['scripts'],
+    jest: {
+      testEnvironment: 'jsdom',
+    },
   },
 };
 

--- a/src/templates/template.d.ts
+++ b/src/templates/template.d.ts
@@ -6,5 +6,6 @@ interface Template {
   packageJson: PackageJson & {
     husky?: any;
     prettier?: any;
+    jest?: any;
   };
 }


### PR DESCRIPTION
since jest v27, the default test env has been changed to 'node'.
this commit configured it to 'jsdom' in react templates.
refs: https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults