### PR TITLE
feat: add support for dts.config.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ DTS comes with the "battery-pack included" and is part of a complete TypeScript 
 - Jest test runner setup with sensible defaults via `dts test`
 - ESLint with Prettier setup with sensible defaults via `dts lint`
 - Zero-config, single dependency
-- Escape hatches for customization via `.babelrc.js`, `jest.config.js`, `.eslintrc.js`, and `dts.config.js`
+- Escape hatches for customization via `.babelrc.js`, `jest.config.js`, `.eslintrc.js`, and `dts.config.js`/`dts.config.ts`
 
 ## Quick Start
 
@@ -336,7 +336,9 @@ DTS can automatically rollup TypeScript type definitions into a single `index.d.
 > **❗⚠️❗ Warning**: <br>
 > These modifications will override the default behavior and configuration of DTS. As such they can invalidate internal guarantees and assumptions. These types of changes can break internal behavior and can be very fragile against updates. Use with discretion!
 
-DTS uses Rollup under the hood. The defaults are solid for most packages (Formik uses the defaults!). However, if you do wish to alter the rollup configuration, you can do so by creating a file called `dts.config.js` at the root of your project like so:
+DTS uses Rollup under the hood. The defaults are solid for most packages (Formik uses the defaults!). However, if you do wish to alter the rollup configuration, you can do so by creating a file called `dts.config.js` (or `dts.config.ts`) at the root of your project like so:
+
+**dts.config.js**
 
 ```js
 // Not transpiled with TypeScript or Babel, so use plain Es6/Node.js!
@@ -348,10 +350,23 @@ module.exports = {
 };
 ```
 
+**dts.config.ts**
+
+```typescript
+import { DtsOptions, RollupOptions } from 'dts-cli';
+
+export default {
+  // This function will run for each entry/format/env combination
+  rollup(config: RollupOptions, options: DtsOptions) {
+    return config; // always return a config.
+  },
+};
+```
+
 The `options` object contains the following:
 
 ```tsx
-export interface TsdxOptions {
+export interface DtsOptions {
   // path to file
   input: string;
   // Name of package

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@release-it/conventional-changelog": "^4.1.0",
+    "@types/cssnano": "^5.0.0",
     "@types/eslint": "^8.4.1",
     "@types/figlet": "^1.5.4",
     "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "bin": {
     "dts": "./dist/index.js"
   },
+  "typings": "./dist/index.d.ts",
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
@@ -106,6 +107,7 @@
     "sort-package-json": "^1.53.1",
     "tiny-glob": "^0.2.9",
     "ts-jest": "^27.1.3",
+    "ts-node": "^10.5.0",
     "tslib": "^2.3.1",
     "type-fest": "^2.10.0",
     "typescript": "^4.5.5"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,8 @@ export const paths = {
   appErrorsJson: resolveApp('errors/codes.json'),
   appErrors: resolveApp('errors'),
   appDist: resolveApp('dist'),
-  appConfig: resolveApp('dts.config.js'),
+  appConfigJs: resolveApp('dts.config.js'),
+  appConfigTs: resolveApp('dts.config.ts'),
   jestConfig: resolveApp('jest.config.js'),
   progressEstimatorCache: resolveApp('node_modules/.cache/.progress-estimator'),
 };

--- a/src/createBuildConfigs.ts
+++ b/src/createBuildConfigs.ts
@@ -6,6 +6,8 @@ import { paths } from './constants';
 import { DtsOptions, NormalizedOpts, PackageJson } from './types';
 
 import { createRollupConfig } from './createRollupConfig';
+import logError from './logError';
+import { interopRequireDefault } from './utils';
 
 // check for custom dts.config.js
 let dtsBuildConfig = {
@@ -14,8 +16,20 @@ let dtsBuildConfig = {
   },
 };
 
-if (fs.existsSync(paths.appConfig)) {
-  dtsBuildConfig = require(paths.appConfig);
+if (fs.existsSync(paths.appConfigTs)) {
+  try {
+    require('ts-node').register({
+      compilerOptions: {
+        module: 'CommonJS',
+      },
+    });
+    dtsBuildConfig = interopRequireDefault(require(paths.appConfigTs)).default;
+  } catch (error) {
+    logError(error);
+    process.exit(1);
+  }
+} else if (fs.existsSync(paths.appConfigJs)) {
+  dtsBuildConfig = require(paths.appConfigJs);
 }
 
 export async function createBuildConfigs(

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,3 +655,6 @@ prog
   );
 
 prog.parse(process.argv);
+
+export { RollupOptions } from 'rollup';
+export { DtsOptions } from './types';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,3 +51,8 @@ export function getReactVersion({
 export function getNodeEngineRequirement({ engines }: PackageJson) {
   return engines && engines.node;
 }
+
+// copied from https://github.com/facebook/jest/blob/5b14366bf3726d48c67b1c6609764556052d909f/packages/jest-util/src/interopRequireDefault.ts#L10
+export function interopRequireDefault(obj: any): any {
+  return obj && obj.__esModule ? obj : { default: obj };
+}

--- a/test/integration/dts-build-withConfigTs.test.ts
+++ b/test/integration/dts-build-withConfigTs.test.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs-extra';
+import * as shell from 'shelljs';
+
+import * as util from '../utils/fixture';
+import { execWithCache } from '../utils/shell';
+
+shell.config.silent = false;
+
+const testDir = 'integration';
+const fixtureName = 'build-withConfigTs';
+const stageName = `stage-integration-${fixtureName}`;
+
+describe('integration :: dts build :: dts-config.ts', () => {
+  beforeAll(() => {
+    util.teardownStage(stageName);
+    util.setupStageWithFixture(testDir, stageName, fixtureName);
+  });
+
+  it('should create a CSS file in the dist/ directory', () => {
+    const output = execWithCache('node ../dist/index.js build');
+
+    // TODO: this is kind of subpar naming, rollup-plugin-postcss just names it
+    // the same as the output file, but with the .css extension
+    expect(shell.test('-f', 'dist/build-withconfigts.cjs.development.css'));
+
+    expect(output.code).toBe(0);
+  });
+
+  it('should autoprefix and minify the CSS file', async () => {
+    const output = execWithCache('node ../dist/index.js build');
+
+    const cssText = await fs.readFile(
+      './dist/build-withconfigts.cjs.development.css'
+    );
+
+    // autoprefixed and minifed output
+    expect(
+      cssText.includes('.test::-moz-placeholder{color:"blue"}')
+    ).toBeTruthy();
+
+    expect(output.code).toBe(0);
+  });
+
+  it('should compile files into a dist directory', () => {
+    const output = execWithCache('node ../dist/index.js build');
+
+    expect(shell.test('-f', 'dist/index.js')).toBeTruthy();
+    expect(
+      shell.test('-f', 'dist/build-withconfigts.cjs.development.js')
+    ).toBeTruthy();
+    expect(
+      shell.test('-f', 'dist/build-withconfigts.cjs.production.min.js')
+    ).toBeTruthy();
+    expect(shell.test('-f', 'dist/build-withconfigts.esm.js')).toBeTruthy();
+
+    expect(shell.test('-f', 'dist/index.d.ts')).toBeTruthy();
+
+    expect(output.code).toBe(0);
+  });
+
+  afterAll(() => {
+    util.teardownStage(stageName);
+  });
+});

--- a/test/integration/fixtures/build-withConfigTs/dts.config.ts
+++ b/test/integration/fixtures/build-withConfigTs/dts.config.ts
@@ -1,0 +1,24 @@
+import { DtsOptions, RollupOptions } from '../src';
+
+const postcss = require('rollup-plugin-postcss');
+const autoprefixer = require('autoprefixer');
+const cssnano = require('cssnano');
+
+export default {
+  rollup(config: RollupOptions, options: DtsOptions) {
+    config?.plugins?.push(
+      postcss({
+        plugins: [
+          autoprefixer(),
+          cssnano({
+            preset: 'default',
+          }),
+        ],
+        inject: false,
+        // only write out CSS for the first bundle (avoids pointless extra files):
+        extract: !!options.writeMeta,
+      })
+    );
+    return config;
+  },
+};

--- a/test/integration/fixtures/build-withConfigTs/dts.config.ts
+++ b/test/integration/fixtures/build-withConfigTs/dts.config.ts
@@ -1,19 +1,25 @@
 import { DtsOptions, RollupOptions } from '../src';
+import autoprefixer from 'autoprefixer';
+import cssnano from 'cssnano';
+import postcss from 'rollup-plugin-postcss';
 
-const postcss = require('rollup-plugin-postcss');
-const autoprefixer = require('autoprefixer');
-const cssnano = require('cssnano');
+// This is necessary due to how typechecking works with the @types/cssnano
+// package. If you remove the `if` check below and attempt to add the cssnano
+// processor directly, you run into issues with type stack depth.
+const getPlugins = () => {
+  const plugins: any[] = [autoprefixer()];
+  const cssnanoProcessor = cssnano({ preset: 'default' });
+  if ('version' in cssnanoProcessor) {
+    plugins.push(cssnanoProcessor);
+  }
+  return plugins;
+};
 
 export default {
   rollup(config: RollupOptions, options: DtsOptions) {
     config?.plugins?.push(
       postcss({
-        plugins: [
-          autoprefixer(),
-          cssnano({
-            preset: 'default',
-          }),
-        ],
+        plugins: getPlugins(),
         inject: false,
         // only write out CSS for the first bundle (avoids pointless extra files):
         extract: !!options.writeMeta,

--- a/test/integration/fixtures/build-withConfigTs/package.json
+++ b/test/integration/fixtures/build-withConfigTs/package.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "build": "dts build"
+  },
+  "name": "build-withconfigts",
+  "license": "MIT"
+}

--- a/test/integration/fixtures/build-withConfigTs/src/index.css
+++ b/test/integration/fixtures/build-withConfigTs/src/index.css
@@ -1,0 +1,4 @@
+/* ::placeholder should be autoprefixed, and everything minified */
+.test::placeholder {
+  color: 'blue';
+}

--- a/test/integration/fixtures/build-withConfigTs/src/index.ts
+++ b/test/integration/fixtures/build-withConfigTs/src/index.ts
@@ -1,0 +1,8 @@
+import './index.css';
+
+export const sum = (a: number, b: number) => {
+  if ('development' === process.env.NODE_ENV) {
+    console.log('dev only output');
+  }
+  return a + b;
+};

--- a/test/integration/fixtures/build-withConfigTs/tsconfig.json
+++ b/test/integration/fixtures/build-withConfigTs/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "ESNext",
+    "lib": ["dom", "esnext"],
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "paths": {
+      "dts-cli": ["../src"]
+    }
+  },
+  "include": ["src", "types"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "importHelpers": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "declaration": false,
+    "declaration": true,
     "module": "commonjs",
     "rootDir": "src",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,6 +4918,7 @@ __metadata:
     tiny-invariant: ^1.2.0
     tiny-warning: ^1.0.3
     ts-jest: ^27.1.3
+    ts-node: ^10.5.0
     tslib: ^2.3.1
     type-fest: ^2.10.0
     typescript: ^4.5.5
@@ -11552,6 +11553,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-node@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "ts-node@npm:10.5.0"
+  dependencies:
+    "@cspotcode/source-map-support": 0.7.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.0
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: d51ac8a9b3582ce3705cef8d35f3372e40caa277dbd7c7baeb651961538f13d2f11f22402614348f78d9b10501bd1cb5f05ec4f2ec9a74bd0e288de769c32335
+  languageName: node
+  linkType: hard
+
 "ts-type@npm:^2.1.4":
   version: 2.1.4
   resolution: "ts-type@npm:2.1.4"
@@ -11988,6 +12026,13 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "v8-compile-cache-lib@npm:3.0.0"
+  checksum: 674e312bbca796584b61dc915f33c7e7dc4e06d196e0048cb772c8964493a1ec723f1dd014d9419fd55c24a6eae148f60769da23f622e05cd13268063fa1ed6b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,6 +2260,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cssnano@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@types/cssnano@npm:5.0.0"
+  dependencies:
+    postcss: ^8
+  checksum: 7d05401db3c419a0bdab9a2889e5a8568dca33b9fedb4cb0ba883d13d76f436cc99f0b25317630cd10d4f1700577a70b76e83a37684589e3541a05aa3b31662f
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^8.4.1":
   version: 8.4.1
   resolution: "@types/eslint@npm:8.4.1"
@@ -4843,6 +4852,7 @@ __metadata:
     "@rollup/plugin-json": ^4.1.0
     "@rollup/plugin-node-resolve": ^13.1.3
     "@rollup/plugin-replace": ^3.0.1
+    "@types/cssnano": ^5.0.0
     "@types/eslint": ^8.4.1
     "@types/figlet": ^1.5.4
     "@types/fs-extra": ^9.0.13
@@ -8436,7 +8446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.30":
+"nanoid@npm:^3.1.30, nanoid@npm:^3.2.0":
   version: 3.2.0
   resolution: "nanoid@npm:3.2.0"
   bin:
@@ -9576,6 +9586,17 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8":
+  version: 8.4.6
+  resolution: "postcss@npm:8.4.6"
+  dependencies:
+    nanoid: ^3.2.0
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 60e7808f39c4a9d0fa067bfd5eb906168c4eb6d3ff0093f7d314d1979b001a16363deedccd368a7df869c63ad4ae350d27da439c94ff3fb0f8fc93d49fe38a90
   languageName: node
   linkType: hard
 
@@ -10758,7 +10779,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: c049a7fc4deb9a7e9b481ae3d424cc793cb4845daa690bc5a05d428bf41bf231ced49b4cf0c9e77f9d42fdb3d20d6187619fc586605f5eabe995a316da8d377c


### PR DESCRIPTION
attempts to load dts.config.ts if it is available,
throws an error if unable to load it. if dts.config.ts
isn't available, moves on to check for dts.config.js.

enables type declarations in tsconfig.json so that
people can import types correctly.

might be worth splitting the current index.ts into multiple
files: one that effectively handles exporting all of the types
(`index.ts`) and one that handles the CLI itself (`cli.ts`). this
would be inline with how the templates used by the project
split things.

closes #128