### PR TITLE
fix: update pkg.engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "conf"
   ],
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^16.0.0 || >=18.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.20.5",


### PR DESCRIPTION
node.js<16 should have been dropped in https://github.com/weiran-zsd/dts-cli/commit/38fbed3425a219330ec20f50ce2076ab49999e6c